### PR TITLE
build instructions add Fedora installation

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -133,6 +133,15 @@ libqrencode (optional) can be installed with:
 Once these are installed, they will be found by configure and a smileycoin-qt executable will be
 built by default.
 
+Dependencies quick start: Fedora
+---------------------------------------
+
+Install required dependencies with:
+
+	sudo dnf install g++ autoconf automake libdb-cxx-devel boost-devel openssl-devel
+
+Then do ``./autogen.sh``, ``./configure``, ``make`` as above.
+
 Notes
 -----
 The release is built with GCC and then "strip smileycoind" to strip the debug


### PR DESCRIPTION
Add installation instructions CLI only for fedora to doc/build-unix.